### PR TITLE
fix: Using newline syntax to fix indentation issues 

### DIFF
--- a/docs/operator-manual/notifications/catalog.md
+++ b/docs/operator-manual/notifications/catalog.md
@@ -58,16 +58,7 @@ slack:
       },
       {
         "title": "Repository",
-        "value": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+        "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         "short": true
       },
       {
@@ -96,16 +87,7 @@ teams:
     },
     {
       "name": "Repository",
-      "value": |
-        {{- if .app.spec.source }}
-          "{{ .app.spec.source.repoURL }}"
-        {{- else if .app.spec.sources }}
-          {{- range .app.spec.sources }}
-            "{{ .repoURL }}"
-          {{- end }}
-        {{- else }}
-          "no repoURL"
-        {{- end }}
+      "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
     },
     {
       "name": "Revision",
@@ -133,16 +115,7 @@ teams:
       "name":"Open Repository",
       "targets":[{
         "os":"default",
-        "uri": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+        "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
       }]
     }]
   themeColor: '#000080'
@@ -171,16 +144,7 @@ slack:
       },
       {
         "title": "Repository",
-        "value": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+        "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         "short": true
       }
       {{range $index, $c := .app.status.conditions}}
@@ -204,16 +168,7 @@ teams:
     },
     {
       "name": "Repository",
-      "value": |
-        {{- if .app.spec.source }}
-          "{{ .app.spec.source.repoURL }}"
-        {{- else if .app.spec.sources }}
-          {{- range .app.spec.sources }}
-            "{{ .repoURL }}"
-          {{- end }}
-        {{- else }}
-          "no repoURL"
-        {{- end }}
+      "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
     }
     {{range $index, $c := .app.status.conditions}}
       ,
@@ -237,16 +192,7 @@ teams:
       "name":"Open Repository",
       "targets":[{
         "os":"default",
-        "uri": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+        "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
       }]
     }]
   themeColor: '#FF0000'
@@ -275,16 +221,7 @@ slack:
       },
       {
         "title": "Repository",
-        "value": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+        "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         "short": true
       }
       {{range $index, $c := .app.status.conditions}}
@@ -312,16 +249,7 @@ teams:
     },
     {
       "name": "Repository",
-      "value": |
-        {{- if .app.spec.source }}
-          "{{ .app.spec.source.repoURL }}"
-        {{- else if .app.spec.sources }}
-          {{- range .app.spec.sources }}
-            "{{ .repoURL }}"
-          {{- end }}
-        {{- else }}
-          "no repoURL"
-        {{- end }}
+      "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
     }
     {{range $index, $c := .app.status.conditions}}
       ,
@@ -345,16 +273,7 @@ teams:
       "name":"Open Repository",
       "targets":[{
         "os":"default",
-        "uri": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+        "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
       }]
     }]
   themeColor: '#FF0000'
@@ -383,16 +302,7 @@ slack:
       },
       {
         "title": "Repository",
-        "value": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+        "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         "short": true
       }
       {{range $index, $c := .app.status.conditions}}
@@ -420,16 +330,7 @@ teams:
     },
     {
       "name": "Repository",
-      "value": |
-        {{- if .app.spec.source }}
-          "{{ .app.spec.source.repoURL }}"
-        {{- else if .app.spec.sources }}
-          {{- range .app.spec.sources }}
-            "{{ .repoURL }}"
-          {{- end }}
-        {{- else }}
-          "no repoURL"
-        {{- end }}
+      "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
     }
     {{range $index, $c := .app.status.conditions}}
       ,
@@ -453,16 +354,7 @@ teams:
       "name":"Open Repository",
       "targets":[{
         "os":"default",
-        "uri": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+        "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
       }]
     }]
   title: Start syncing application {{.app.metadata.name}}.
@@ -495,16 +387,7 @@ slack:
       },
       {
         "title": "Repository",
-        "value": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+        "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         "short": true
       }
       {{range $index, $c := .app.status.conditions}}
@@ -528,16 +411,7 @@ teams:
     },
     {
       "name": "Repository",
-      "value": |
-      {{- if .app.spec.source }}
-        "{{ .app.spec.source.repoURL }}"
-      {{- else if .app.spec.sources }}
-        {{- range .app.spec.sources }}
-          "{{ .repoURL }}"
-        {{- end }}
-      {{- else }}
-        "no repoURL"
-      {{- end }}
+      "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
     }
     {{range $index, $c := .app.status.conditions}}
       ,
@@ -561,16 +435,7 @@ teams:
       "name":"Open Repository",
       "targets":[{
         "os":"default",
-        "uri": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+        "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
       }]
     }]
   title: Application {{.app.metadata.name}} sync status is 'Unknown'
@@ -598,16 +463,7 @@ slack:
       },
       {
         "title": "Repository",
-        "value": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+        "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         "short": true
       }
       {{range $index, $c := .app.status.conditions}}
@@ -635,16 +491,7 @@ teams:
     },
     {
       "name": "Repository",
-      "value": |
-        {{- if .app.spec.source }}
-          "{{ .app.spec.source.repoURL }}"
-        {{- else if .app.spec.sources }}
-          {{- range .app.spec.sources }}
-            "{{ .repoURL }}"
-          {{- end }}
-        {{- else }}
-          "no repoURL"
-        {{- end }}
+      "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
     }
     {{range $index, $c := .app.status.conditions}}
       ,
@@ -668,16 +515,7 @@ teams:
       "name":"Open Repository",
       "targets":[{
         "os":"default",
-        "uri": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL | call .repo.RepoURLToHTTPS }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL | call .repo.RepoURLToHTTPS }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+        "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
       }]
     }]
   themeColor: '#000080'

--- a/docs/operator-manual/notifications/catalog.md
+++ b/docs/operator-manual/notifications/catalog.md
@@ -45,36 +45,106 @@ email:
 message: |
   {{if eq .serviceType "slack"}}:white_check_mark:{{end}} Application {{.app.metadata.name}} is now running new version of deployments manifests.
 slack:
-  attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-    \ \"color\": \"#18be52\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
-    \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
-    \   \"title\": \"Repository\",\n    \"value\": \n      {{- if .app.spec.source
-    }}\n        \"{{ .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources
-    }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{-
-    end }}\n      {{- else }}\n        \"no repoURL\"\n      {{- end }}\n    \"short\":
-    true\n  },\n  {\n    \"title\": \"Revision\",\n    \"value\": \"{{.app.status.sync.revision}}\",\n
-    \   \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  ,\n
-    \ {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\":
-    true\n  }\n  {{end}}\n  ]\n}]\n"
+  attachments: |
+    [{
+      "title": "{{ .app.metadata.name}}",
+      "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+      "color": "#18be52",
+      "fields": [
+      {
+        "title": "Sync Status",
+        "value": "{{.app.status.sync.status}}",
+        "short": true
+      },
+      {
+        "title": "Repository",
+        "value": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+        "short": true
+      },
+      {
+        "title": "Revision",
+        "value": "{{.app.status.sync.revision}}",
+        "short": true
+      }
+      {{range $index, $c := .app.status.conditions}}
+      ,
+      {
+        "title": "{{$c.type}}",
+        "value": "{{$c.message}}",
+        "short": true
+      }
+      {{end}}
+      ]
+    }]
   deliveryPolicy: Post
   groupingKey: ""
   notifyBroadcast: false
 teams:
-  facts: "[{\n  \"name\": \"Sync Status\",\n  \"value\": \"{{.app.status.sync.status}}\"\n},\n{\n
-    \ \"name\": \"Repository\",\n  \"value\": \n    {{- if .app.spec.source }}\n      \"{{
-    .app.spec.source.repoURL }}\"\n    {{- else if .app.spec.sources }}\n      {{-
-    range .app.spec.sources }}\n        \"{{ .repoURL }}\"\n      {{- end }}\n    {{-
-    else }}\n      \"no repoURL\"\n    {{- end }}\n},\n{\n  \"name\": \"Revision\",\n
-    \ \"value\": \"{{.app.status.sync.revision}}\"\n}\n{{range $index, $c := .app.status.conditions}}\n
-    \ ,\n  {\n    \"name\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\"\n
-    \ }\n{{end}}\n]\n"
-  potentialAction: "[{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Operation Application\",\n
-    \ \"targets\":[{\n    \"os\":\"default\",\n    \"uri\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\"\n
-    \ }]\n},\n{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Repository\",\n  \"targets\":[{\n
-    \   \"os\":\"default\",\n    \"uri\": \n      {{- if .app.spec.source }}\n        \"{{
-    .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources }}\n        {{-
-    range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{- end }}\n
-    \     {{- else }}\n        \"no repoURL\"\n      {{- end }}\n  }]\n}]"
+  facts: |
+    [{
+      "name": "Sync Status",
+      "value": "{{.app.status.sync.status}}"
+    },
+    {
+      "name": "Repository",
+      "value": |
+        {{- if .app.spec.source }}
+          "{{ .app.spec.source.repoURL }}"
+        {{- else if .app.spec.sources }}
+          {{- range .app.spec.sources }}
+            "{{ .repoURL }}"
+          {{- end }}
+        {{- else }}
+          "no repoURL"
+        {{- end }}
+    },
+    {
+      "name": "Revision",
+      "value": "{{.app.status.sync.revision}}"
+    }
+    {{range $index, $c := .app.status.conditions}}
+      ,
+      {
+        "name": "{{$c.type}}",
+        "value": "{{$c.message}}"
+      }
+    {{end}}
+    ]
+  potentialAction: |-
+    [{
+      "@type":"OpenUri",
+      "name":"Operation Application",
+      "targets":[{
+        "os":"default",
+        "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+      }]
+    },
+    {
+      "@type":"OpenUri",
+      "name":"Open Repository",
+      "targets":[{
+        "os":"default",
+        "uri": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+      }]
+    }]
   themeColor: '#000080'
   title: New version of an application {{.app.metadata.name}} is up and running.
 
@@ -88,34 +158,97 @@ message: |
   {{if eq .serviceType "slack"}}:exclamation:{{end}} Application {{.app.metadata.name}} has degraded.
   Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
 slack:
-  attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\": \"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-    \ \"color\": \"#f4c030\",\n  \"fields\": [\n  {\n    \"title\": \"Health Status\",\n
-    \   \"value\": \"{{.app.status.health.status}}\",\n    \"short\": true\n  },\n
-    \ {\n    \"title\": \"Repository\",\n    \"value\": \n      {{- if .app.spec.source
-    }}\n        \"{{ .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources
-    }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{-
-    end }}\n      {{- else }}\n        \"no repoURL\"\n      {{- end }}\n    \"short\":
-    true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  ,\n  {\n    \"title\":
-    \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n
-    \ {{end}}\n  ]\n}]\n"
+  attachments: |
+    [{
+      "title": "{{ .app.metadata.name}}",
+      "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+      "color": "#f4c030",
+      "fields": [
+      {
+        "title": "Health Status",
+        "value": "{{.app.status.health.status}}",
+        "short": true
+      },
+      {
+        "title": "Repository",
+        "value": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+        "short": true
+      }
+      {{range $index, $c := .app.status.conditions}}
+      ,
+      {
+        "title": "{{$c.type}}",
+        "value": "{{$c.message}}",
+        "short": true
+      }
+      {{end}}
+      ]
+    }]
   deliveryPolicy: Post
   groupingKey: ""
   notifyBroadcast: false
 teams:
-  facts: "[{\n  \"name\": \"Health Status\",\n  \"value\": \"{{.app.status.health.status}}\"\n},\n{\n
-    \ \"name\": \"Repository\",\n  \"value\": \n    {{- if .app.spec.source }}\n      \"{{
-    .app.spec.source.repoURL }}\"\n    {{- else if .app.spec.sources }}\n      {{-
-    range .app.spec.sources }}\n        \"{{ .repoURL }}\"\n      {{- end }}\n    {{-
-    else }}\n      \"no repoURL\"\n    {{- end }}\n}\n{{range $index, $c := .app.status.conditions}}\n
-    \ ,\n  {\n    \"name\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\"\n
-    \ }\n{{end}}\n]\n"
-  potentialAction: "[{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Application\",\n
-    \ \"targets\":[{\n    \"os\":\"default\",\n    \"uri\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\"\n
-    \ }]\n},\n{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Repository\",\n  \"targets\":[{\n
-    \   \"os\":\"default\",\n    \"uri\": \n      {{- if .app.spec.source }}\n        \"{{
-    .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources }}\n        {{-
-    range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{- end }}\n
-    \     {{- else }}\n        \"no repoURL\"\n      {{- end }}\n  }]\n}]\n"
+  facts: |
+    [{
+      "name": "Health Status",
+      "value": "{{.app.status.health.status}}"
+    },
+    {
+      "name": "Repository",
+      "value": |
+        {{- if .app.spec.source }}
+          "{{ .app.spec.source.repoURL }}"
+        {{- else if .app.spec.sources }}
+          {{- range .app.spec.sources }}
+            "{{ .repoURL }}"
+          {{- end }}
+        {{- else }}
+          "no repoURL"
+        {{- end }}
+    }
+    {{range $index, $c := .app.status.conditions}}
+      ,
+      {
+        "name": "{{$c.type}}",
+        "value": "{{$c.message}}"
+      }
+    {{end}}
+    ]
+  potentialAction: |-
+    [{
+      "@type":"OpenUri",
+      "name":"Open Application",
+      "targets":[{
+        "os":"default",
+        "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+      }]
+    },
+    {
+      "@type":"OpenUri",
+      "name":"Open Repository",
+      "targets":[{
+        "os":"default",
+        "uri": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+      }]
+    }]
   themeColor: '#FF0000'
   title: Application {{.app.metadata.name}} has degraded.
 
@@ -129,35 +262,101 @@ message: |
   {{if eq .serviceType "slack"}}:exclamation:{{end}}  The sync operation of application {{.app.metadata.name}} has failed at {{.app.status.operationState.finishedAt}} with the following error: {{.app.status.operationState.message}}
   Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
 slack:
-  attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-    \ \"color\": \"#E96D76\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
-    \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
-    \   \"title\": \"Repository\",\n    \"value\": \n      {{- if .app.spec.source
-    }}\n        \"{{ .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources
-    }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{-
-    end }}\n      {{- else }}\n        \"no repoURL\"\n      {{- end }}\n    \"short\":
-    true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  ,\n  {\n    \"title\":
-    \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n
-    \ {{end}}\n  ]\n}]\n"
+  attachments: |
+    [{
+      "title": "{{ .app.metadata.name}}",
+      "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+      "color": "#E96D76",
+      "fields": [
+      {
+        "title": "Sync Status",
+        "value": "{{.app.status.sync.status}}",
+        "short": true
+      },
+      {
+        "title": "Repository",
+        "value": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+        "short": true
+      }
+      {{range $index, $c := .app.status.conditions}}
+      ,
+      {
+        "title": "{{$c.type}}",
+        "value": "{{$c.message}}",
+        "short": true
+      }
+      {{end}}
+      ]
+    }]
   deliveryPolicy: Post
   groupingKey: ""
   notifyBroadcast: false
 teams:
-  facts: "[{\n  \"name\": \"Sync Status\",\n  \"value\": \"{{.app.status.sync.status}}\"\n},\n{\n
-    \ \"name\": \"Failed at\",\n  \"value\": \"{{.app.status.operationState.finishedAt}}\"\n},\n{\n
-    \ \"name\": \"Repository\",\n  \"value\": \n    {{- if .app.spec.source }}\n      \"{{
-    .app.spec.source.repoURL }}\"\n    {{- else if .app.spec.sources }}\n      {{-
-    range .app.spec.sources }}\n        \"{{ .repoURL }}\"\n      {{- end }}\n    {{-
-    else }}\n      \"no repoURL\"\n    {{- end }}\n}\n{{range $index, $c := .app.status.conditions}}\n
-    \ ,\n  {\n    \"name\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\"\n
-    \ }\n{{end}}\n]\n"
-  potentialAction: "[{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Operation\",\n
-    \ \"targets\":[{\n    \"os\":\"default\",\n    \"uri\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true\"\n
-    \ }]\n},\n{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Repository\",\n  \"targets\":[{\n
-    \   \"os\":\"default\",\n    \"uri\": \n      {{- if .app.spec.source }}\n        \"{{
-    .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources }}\n        {{-
-    range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{- end }}\n
-    \     {{- else }}\n        \"no repoURL\"\n      {{- end }} \n  }]\n}]"
+  facts: |
+    [{
+      "name": "Sync Status",
+      "value": "{{.app.status.sync.status}}"
+    },
+    {
+      "name": "Failed at",
+      "value": "{{.app.status.operationState.finishedAt}}"
+    },
+    {
+      "name": "Repository",
+      "value": |
+        {{- if .app.spec.source }}
+          "{{ .app.spec.source.repoURL }}"
+        {{- else if .app.spec.sources }}
+          {{- range .app.spec.sources }}
+            "{{ .repoURL }}"
+          {{- end }}
+        {{- else }}
+          "no repoURL"
+        {{- end }}
+    }
+    {{range $index, $c := .app.status.conditions}}
+      ,
+      {
+        "name": "{{$c.type}}",
+        "value": "{{$c.message}}"
+      }
+    {{end}}
+    ]
+  potentialAction: |-
+    [{
+      "@type":"OpenUri",
+      "name":"Open Operation",
+      "targets":[{
+        "os":"default",
+        "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+      }]
+    },
+    {
+      "@type":"OpenUri",
+      "name":"Open Repository",
+      "targets":[{
+        "os":"default",
+        "uri": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+      }]
+    }]
   themeColor: '#FF0000'
   title: Failed to sync application {{.app.metadata.name}}.
 
@@ -171,35 +370,101 @@ message: |
   The sync operation of application {{.app.metadata.name}} has started at {{.app.status.operationState.startedAt}}.
   Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
 slack:
-  attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-    \ \"color\": \"#0DADEA\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
-    \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
-    \   \"title\": \"Repository\",\n    \"value\": \n      {{- if .app.spec.source
-    }}\n        \"{{ .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources
-    }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{-
-    end }}\n      {{- else }}\n        \"no repoURL\"\n      {{- end }}\n    \"short\":
-    true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  ,\n  {\n    \"title\":
-    \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n
-    \ {{end}}\n  ]\n}]\n"
+  attachments: |
+    [{
+      "title": "{{ .app.metadata.name}}",
+      "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+      "color": "#0DADEA",
+      "fields": [
+      {
+        "title": "Sync Status",
+        "value": "{{.app.status.sync.status}}",
+        "short": true
+      },
+      {
+        "title": "Repository",
+        "value": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+        "short": true
+      }
+      {{range $index, $c := .app.status.conditions}}
+      ,
+      {
+        "title": "{{$c.type}}",
+        "value": "{{$c.message}}",
+        "short": true
+      }
+      {{end}}
+      ]
+    }]
   deliveryPolicy: Post
   groupingKey: ""
   notifyBroadcast: false
 teams:
-  facts: "[{\n  \"name\": \"Sync Status\",\n  \"value\": \"{{.app.status.sync.status}}\"\n},\n{\n
-    \ \"name\": \"Started at\",\n  \"value\": \"{{.app.status.operationState.startedAt}}\"\n},\n{\n
-    \ \"name\": \"Repository\",\n  \"value\": \n    {{- if .app.spec.source }}\n      \"{{
-    .app.spec.source.repoURL }}\"\n    {{- else if .app.spec.sources }}\n      {{-
-    range .app.spec.sources }}\n        \"{{ .repoURL }}\"\n      {{- end }}\n    {{-
-    else }}\n      \"no repoURL\"\n    {{- end }}\n}\n{{range $index, $c := .app.status.conditions}}\n
-    \ ,\n  {\n    \"name\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\"\n
-    \ }\n{{end}}\n]\n"
-  potentialAction: "[{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Operation\",\n
-    \ \"targets\":[{\n    \"os\":\"default\",\n    \"uri\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true\"\n
-    \ }]\n},\n{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Repository\",\n  \"targets\":[{\n
-    \   \"os\":\"default\",\n    \"uri\": \n      {{- if .app.spec.source }}\n        \"{{
-    .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources }}\n        {{-
-    range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{- end }}\n
-    \     {{- else }}\n        \"no repoURL\"\n      {{- end }} \n  }]\n}]"
+  facts: |
+    [{
+      "name": "Sync Status",
+      "value": "{{.app.status.sync.status}}"
+    },
+    {
+      "name": "Started at",
+      "value": "{{.app.status.operationState.startedAt}}"
+    },
+    {
+      "name": "Repository",
+      "value": |
+        {{- if .app.spec.source }}
+          "{{ .app.spec.source.repoURL }}"
+        {{- else if .app.spec.sources }}
+          {{- range .app.spec.sources }}
+            "{{ .repoURL }}"
+          {{- end }}
+        {{- else }}
+          "no repoURL"
+        {{- end }}
+    }
+    {{range $index, $c := .app.status.conditions}}
+      ,
+      {
+        "name": "{{$c.type}}",
+        "value": "{{$c.message}}"
+      }
+    {{end}}
+    ]
+  potentialAction: |-
+    [{
+      "@type":"OpenUri",
+      "name":"Open Operation",
+      "targets":[{
+        "os":"default",
+        "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+      }]
+    },
+    {
+      "@type":"OpenUri",
+      "name":"Open Repository",
+      "targets":[{
+        "os":"default",
+        "uri": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+      }]
+    }]
   title: Start syncing application {{.app.metadata.name}}.
 
 ```
@@ -217,34 +482,97 @@ message: |
   {{end}}
   {{end}}
 slack:
-  attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-    \ \"color\": \"#E96D76\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
-    \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
-    \   \"title\": \"Repository\",\n    \"value\": \n      {{- if .app.spec.source
-    }}\n        \"{{ .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources
-    }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{-
-    end }}\n      {{- else }}\n        \"no repoURL\"\n      {{- end }}\n    \"short\":
-    true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  ,\n  {\n    \"title\":
-    \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n
-    \ {{end}}\n  ]\n}]\n"
+  attachments: |
+    [{
+      "title": "{{ .app.metadata.name}}",
+      "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+      "color": "#E96D76",
+      "fields": [
+      {
+        "title": "Sync Status",
+        "value": "{{.app.status.sync.status}}",
+        "short": true
+      },
+      {
+        "title": "Repository",
+        "value": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+        "short": true
+      }
+      {{range $index, $c := .app.status.conditions}}
+      ,
+      {
+        "title": "{{$c.type}}",
+        "value": "{{$c.message}}",
+        "short": true
+      }
+      {{end}}
+      ]
+    }]
   deliveryPolicy: Post
   groupingKey: ""
   notifyBroadcast: false
 teams:
-  facts: "[{\n  \"name\": \"Sync Status\",\n  \"value\": \"{{.app.status.sync.status}}\"\n},\n{\n
-    \ \"name\": \"Repository\",\n  \"value\": \n  {{- if .app.spec.source }}\n    \"{{
-    .app.spec.source.repoURL }}\"\n  {{- else if .app.spec.sources }}\n    {{- range
-    .app.spec.sources }}\n      \"{{ .repoURL }}\"\n    {{- end }}\n  {{- else }}\n
-    \   \"no repoURL\"\n  {{- end }}\n}\n{{range $index, $c := .app.status.conditions}}\n
-    \ ,\n  {\n    \"name\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\"\n
-    \ }\n{{end}}\n]\n"
-  potentialAction: "[{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Application\",\n
-    \ \"targets\":[{\n    \"os\":\"default\",\n    \"uri\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\"\n
-    \ }]\n},\n{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Repository\",\n  \"targets\":[{\n
-    \   \"os\":\"default\",\n    \"uri\": \n      {{- if .app.spec.source }}\n        \"{{
-    .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources }}\n        {{-
-    range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{- end }}\n
-    \     {{- else }}\n        \"no repoURL\"\n      {{- end }} \n  }]\n}]"
+  facts: |
+    [{
+      "name": "Sync Status",
+      "value": "{{.app.status.sync.status}}"
+    },
+    {
+      "name": "Repository",
+      "value": |
+      {{- if .app.spec.source }}
+        "{{ .app.spec.source.repoURL }}"
+      {{- else if .app.spec.sources }}
+        {{- range .app.spec.sources }}
+          "{{ .repoURL }}"
+        {{- end }}
+      {{- else }}
+        "no repoURL"
+      {{- end }}
+    }
+    {{range $index, $c := .app.status.conditions}}
+      ,
+      {
+        "name": "{{$c.type}}",
+        "value": "{{$c.message}}"
+      }
+    {{end}}
+    ]
+  potentialAction: |-
+    [{
+      "@type":"OpenUri",
+      "name":"Open Application",
+      "targets":[{
+        "os":"default",
+        "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+      }]
+    },
+    {
+      "@type":"OpenUri",
+      "name":"Open Repository",
+      "targets":[{
+        "os":"default",
+        "uri": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+      }]
+    }]
   title: Application {{.app.metadata.name}} sync status is 'Unknown'
 
 ```
@@ -257,36 +585,101 @@ message: |
   {{if eq .serviceType "slack"}}:white_check_mark:{{end}} Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.
   Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
 slack:
-  attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-    \ \"color\": \"#18be52\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
-    \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
-    \   \"title\": \"Repository\",\n    \"value\": \n      {{- if .app.spec.source
-    }}\n        \"{{ .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources
-    }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{-
-    end }}\n      {{- else }}\n        \"no repoURL\"\n      {{- end }}\n    \"short\":
-    true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  ,\n  {\n    \"title\":
-    \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n
-    \ {{end}}\n  ]\n}]\n"
+  attachments: |
+    [{
+      "title": "{{ .app.metadata.name}}",
+      "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+      "color": "#18be52",
+      "fields": [
+      {
+        "title": "Sync Status",
+        "value": "{{.app.status.sync.status}}",
+        "short": true
+      },
+      {
+        "title": "Repository",
+        "value": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+        "short": true
+      }
+      {{range $index, $c := .app.status.conditions}}
+      ,
+      {
+        "title": "{{$c.type}}",
+        "value": "{{$c.message}}",
+        "short": true
+      }
+      {{end}}
+      ]
+    }]
   deliveryPolicy: Post
   groupingKey: ""
   notifyBroadcast: false
 teams:
-  facts: "[{\n  \"name\": \"Sync Status\",\n  \"value\": \"{{.app.status.sync.status}}\"\n},\n{\n
-    \ \"name\": \"Synced at\",\n  \"value\": \"{{.app.status.operationState.finishedAt}}\"\n},\n{\n
-    \ \"name\": \"Repository\",\n  \"value\": \n    {{- if .app.spec.source }}\n      \"{{
-    .app.spec.source.repoURL }}\"\n    {{- else if .app.spec.sources }}\n      {{-
-    range .app.spec.sources }}\n        \"{{ .repoURL }}\"\n      {{- end }}\n    {{-
-    else }}\n      \"no repoURL\"\n    {{- end }}\n}\n{{range $index, $c := .app.status.conditions}}\n
-    \ ,\n  {\n    \"name\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\"\n
-    \ }\n{{end}}\n]\n"
-  potentialAction: "[{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Operation Details\",\n
-    \ \"targets\":[{\n    \"os\":\"default\",\n    \"uri\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true\"\n
-    \ }]\n},\n{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Repository\",\n  \"targets\":[{\n
-    \   \"os\":\"default\",\n    \"uri\": \n      {{- if .app.spec.source }}\n        \"{{
-    .app.spec.source.repoURL | call .repo.RepoURLToHTTPS }}\"\n      {{- else if .app.spec.sources
-    }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL | call .repo.RepoURLToHTTPS
-    }}\"\n        {{- end }}\n      {{- else }}\n        \"no repoURL\"\n      {{-
-    end }}\n  }]\n}]"
+  facts: |
+    [{
+      "name": "Sync Status",
+      "value": "{{.app.status.sync.status}}"
+    },
+    {
+      "name": "Synced at",
+      "value": "{{.app.status.operationState.finishedAt}}"
+    },
+    {
+      "name": "Repository",
+      "value": |
+        {{- if .app.spec.source }}
+          "{{ .app.spec.source.repoURL }}"
+        {{- else if .app.spec.sources }}
+          {{- range .app.spec.sources }}
+            "{{ .repoURL }}"
+          {{- end }}
+        {{- else }}
+          "no repoURL"
+        {{- end }}
+    }
+    {{range $index, $c := .app.status.conditions}}
+      ,
+      {
+        "name": "{{$c.type}}",
+        "value": "{{$c.message}}"
+      }
+    {{end}}
+    ]
+  potentialAction: |-
+    [{
+      "@type":"OpenUri",
+      "name":"Operation Details",
+      "targets":[{
+        "os":"default",
+        "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+      }]
+    },
+    {
+      "@type":"OpenUri",
+      "name":"Open Repository",
+      "targets":[{
+        "os":"default",
+        "uri": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL | call .repo.RepoURLToHTTPS }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL | call .repo.RepoURLToHTTPS }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+      }]
+    }]
   themeColor: '#000080'
   title: Application {{.app.metadata.name}} has been successfully synced
 

--- a/notifications_catalog/install.yaml
+++ b/notifications_catalog/install.yaml
@@ -31,16 +31,7 @@ data:
           },
           {
             "title": "Repository",
-            "value": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
             "short": true
           },
           {
@@ -69,16 +60,7 @@ data:
         },
         {
           "name": "Repository",
-          "value": |
-            {{- if .app.spec.source }}
-              "{{ .app.spec.source.repoURL }}"
-            {{- else if .app.spec.sources }}
-              {{- range .app.spec.sources }}
-                "{{ .repoURL }}"
-              {{- end }}
-            {{- else }}
-              "no repoURL"
-            {{- end }}
+          "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         },
         {
           "name": "Revision",
@@ -106,16 +88,7 @@ data:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
           }]
         }]
       themeColor: '#000080'
@@ -140,16 +113,7 @@ data:
           },
           {
             "title": "Repository",
-            "value": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
             "short": true
           }
           {{range $index, $c := .app.status.conditions}}
@@ -173,16 +137,7 @@ data:
         },
         {
           "name": "Repository",
-          "value": |
-            {{- if .app.spec.source }}
-              "{{ .app.spec.source.repoURL }}"
-            {{- else if .app.spec.sources }}
-              {{- range .app.spec.sources }}
-                "{{ .repoURL }}"
-              {{- end }}
-            {{- else }}
-              "no repoURL"
-            {{- end }}
+          "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         }
         {{range $index, $c := .app.status.conditions}}
           ,
@@ -206,16 +161,7 @@ data:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
           }]
         }]
       themeColor: '#FF0000'
@@ -240,16 +186,7 @@ data:
           },
           {
             "title": "Repository",
-            "value": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
             "short": true
           }
           {{range $index, $c := .app.status.conditions}}
@@ -277,16 +214,7 @@ data:
         },
         {
           "name": "Repository",
-          "value": |
-            {{- if .app.spec.source }}
-              "{{ .app.spec.source.repoURL }}"
-            {{- else if .app.spec.sources }}
-              {{- range .app.spec.sources }}
-                "{{ .repoURL }}"
-              {{- end }}
-            {{- else }}
-              "no repoURL"
-            {{- end }}
+          "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         }
         {{range $index, $c := .app.status.conditions}}
           ,
@@ -310,16 +238,7 @@ data:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
           }]
         }]
       themeColor: '#FF0000'
@@ -344,16 +263,7 @@ data:
           },
           {
             "title": "Repository",
-            "value": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
             "short": true
           }
           {{range $index, $c := .app.status.conditions}}
@@ -381,16 +291,7 @@ data:
         },
         {
           "name": "Repository",
-          "value": |
-            {{- if .app.spec.source }}
-              "{{ .app.spec.source.repoURL }}"
-            {{- else if .app.spec.sources }}
-              {{- range .app.spec.sources }}
-                "{{ .repoURL }}"
-              {{- end }}
-            {{- else }}
-              "no repoURL"
-            {{- end }}
+          "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         }
         {{range $index, $c := .app.status.conditions}}
           ,
@@ -414,16 +315,7 @@ data:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
           }]
         }]
       title: Start syncing application {{.app.metadata.name}}.
@@ -452,16 +344,7 @@ data:
           },
           {
             "title": "Repository",
-            "value": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
             "short": true
           }
           {{range $index, $c := .app.status.conditions}}
@@ -485,16 +368,7 @@ data:
         },
         {
           "name": "Repository",
-          "value": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+          "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         }
         {{range $index, $c := .app.status.conditions}}
           ,
@@ -518,16 +392,7 @@ data:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
           }]
         }]
       title: Application {{.app.metadata.name}} sync status is 'Unknown'
@@ -551,16 +416,7 @@ data:
           },
           {
             "title": "Repository",
-            "value": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
             "short": true
           }
           {{range $index, $c := .app.status.conditions}}
@@ -588,16 +444,7 @@ data:
         },
         {
           "name": "Repository",
-          "value": |
-            {{- if .app.spec.source }}
-              "{{ .app.spec.source.repoURL }}"
-            {{- else if .app.spec.sources }}
-              {{- range .app.spec.sources }}
-                "{{ .repoURL }}"
-              {{- end }}
-            {{- else }}
-              "no repoURL"
-            {{- end }}
+          "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         }
         {{range $index, $c := .app.status.conditions}}
           ,
@@ -621,16 +468,7 @@ data:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL | call .repo.RepoURLToHTTPS }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL | call .repo.RepoURLToHTTPS }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
           }]
         }]
       themeColor: '#000080'

--- a/notifications_catalog/install.yaml
+++ b/notifications_catalog/install.yaml
@@ -18,36 +18,106 @@ data:
     message: |
       {{if eq .serviceType "slack"}}:white_check_mark:{{end}} Application {{.app.metadata.name}} is now running new version of deployments manifests.
     slack:
-      attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-        \ \"color\": \"#18be52\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
-        \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
-        \   \"title\": \"Repository\",\n    \"value\": \n      {{- if .app.spec.source
-        }}\n        \"{{ .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources
-        }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{-
-        end }}\n      {{- else }}\n        \"no repoURL\"\n      {{- end }}\n    \"short\":
-        true\n  },\n  {\n    \"title\": \"Revision\",\n    \"value\": \"{{.app.status.sync.revision}}\",\n
-        \   \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  ,\n
-        \ {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\":
-        true\n  }\n  {{end}}\n  ]\n}]\n"
+      attachments: |
+        [{
+          "title": "{{ .app.metadata.name}}",
+          "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+          "color": "#18be52",
+          "fields": [
+          {
+            "title": "Sync Status",
+            "value": "{{.app.status.sync.status}}",
+            "short": true
+          },
+          {
+            "title": "Repository",
+            "value": |
+              {{- if .app.spec.source }}
+                "{{ .app.spec.source.repoURL }}"
+              {{- else if .app.spec.sources }}
+                {{- range .app.spec.sources }}
+                  "{{ .repoURL }}"
+                {{- end }}
+              {{- else }}
+                "no repoURL"
+              {{- end }}
+            "short": true
+          },
+          {
+            "title": "Revision",
+            "value": "{{.app.status.sync.revision}}",
+            "short": true
+          }
+          {{range $index, $c := .app.status.conditions}}
+          ,
+          {
+            "title": "{{$c.type}}",
+            "value": "{{$c.message}}",
+            "short": true
+          }
+          {{end}}
+          ]
+        }]
       deliveryPolicy: Post
       groupingKey: ""
       notifyBroadcast: false
     teams:
-      facts: "[{\n  \"name\": \"Sync Status\",\n  \"value\": \"{{.app.status.sync.status}}\"\n},\n{\n
-        \ \"name\": \"Repository\",\n  \"value\": \n    {{- if .app.spec.source }}\n      \"{{
-        .app.spec.source.repoURL }}\"\n    {{- else if .app.spec.sources }}\n      {{-
-        range .app.spec.sources }}\n        \"{{ .repoURL }}\"\n      {{- end }}\n    {{-
-        else }}\n      \"no repoURL\"\n    {{- end }}\n},\n{\n  \"name\": \"Revision\",\n
-        \ \"value\": \"{{.app.status.sync.revision}}\"\n}\n{{range $index, $c := .app.status.conditions}}\n
-        \ ,\n  {\n    \"name\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\"\n
-        \ }\n{{end}}\n]\n"
-      potentialAction: "[{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Operation Application\",\n
-        \ \"targets\":[{\n    \"os\":\"default\",\n    \"uri\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\"\n
-        \ }]\n},\n{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Repository\",\n  \"targets\":[{\n
-        \   \"os\":\"default\",\n    \"uri\": \n      {{- if .app.spec.source }}\n        \"{{
-        .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources }}\n        {{-
-        range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{- end }}\n
-        \     {{- else }}\n        \"no repoURL\"\n      {{- end }}\n  }]\n}]"
+      facts: |
+        [{
+          "name": "Sync Status",
+          "value": "{{.app.status.sync.status}}"
+        },
+        {
+          "name": "Repository",
+          "value": |
+            {{- if .app.spec.source }}
+              "{{ .app.spec.source.repoURL }}"
+            {{- else if .app.spec.sources }}
+              {{- range .app.spec.sources }}
+                "{{ .repoURL }}"
+              {{- end }}
+            {{- else }}
+              "no repoURL"
+            {{- end }}
+        },
+        {
+          "name": "Revision",
+          "value": "{{.app.status.sync.revision}}"
+        }
+        {{range $index, $c := .app.status.conditions}}
+          ,
+          {
+            "name": "{{$c.type}}",
+            "value": "{{$c.message}}"
+          }
+        {{end}}
+        ]
+      potentialAction: |-
+        [{
+          "@type":"OpenUri",
+          "name":"Operation Application",
+          "targets":[{
+            "os":"default",
+            "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+          }]
+        },
+        {
+          "@type":"OpenUri",
+          "name":"Open Repository",
+          "targets":[{
+            "os":"default",
+            "uri": |
+              {{- if .app.spec.source }}
+                "{{ .app.spec.source.repoURL }}"
+              {{- else if .app.spec.sources }}
+                {{- range .app.spec.sources }}
+                  "{{ .repoURL }}"
+                {{- end }}
+              {{- else }}
+                "no repoURL"
+              {{- end }}
+          }]
+        }]
       themeColor: '#000080'
       title: New version of an application {{.app.metadata.name}} is up and running.
   template.app-health-degraded: |
@@ -57,34 +127,97 @@ data:
       {{if eq .serviceType "slack"}}:exclamation:{{end}} Application {{.app.metadata.name}} has degraded.
       Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
     slack:
-      attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\": \"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-        \ \"color\": \"#f4c030\",\n  \"fields\": [\n  {\n    \"title\": \"Health Status\",\n
-        \   \"value\": \"{{.app.status.health.status}}\",\n    \"short\": true\n  },\n
-        \ {\n    \"title\": \"Repository\",\n    \"value\": \n      {{- if .app.spec.source
-        }}\n        \"{{ .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources
-        }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{-
-        end }}\n      {{- else }}\n        \"no repoURL\"\n      {{- end }}\n    \"short\":
-        true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  ,\n  {\n    \"title\":
-        \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n
-        \ {{end}}\n  ]\n}]\n"
+      attachments: |
+        [{
+          "title": "{{ .app.metadata.name}}",
+          "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+          "color": "#f4c030",
+          "fields": [
+          {
+            "title": "Health Status",
+            "value": "{{.app.status.health.status}}",
+            "short": true
+          },
+          {
+            "title": "Repository",
+            "value": |
+              {{- if .app.spec.source }}
+                "{{ .app.spec.source.repoURL }}"
+              {{- else if .app.spec.sources }}
+                {{- range .app.spec.sources }}
+                  "{{ .repoURL }}"
+                {{- end }}
+              {{- else }}
+                "no repoURL"
+              {{- end }}
+            "short": true
+          }
+          {{range $index, $c := .app.status.conditions}}
+          ,
+          {
+            "title": "{{$c.type}}",
+            "value": "{{$c.message}}",
+            "short": true
+          }
+          {{end}}
+          ]
+        }]
       deliveryPolicy: Post
       groupingKey: ""
       notifyBroadcast: false
     teams:
-      facts: "[{\n  \"name\": \"Health Status\",\n  \"value\": \"{{.app.status.health.status}}\"\n},\n{\n
-        \ \"name\": \"Repository\",\n  \"value\": \n    {{- if .app.spec.source }}\n      \"{{
-        .app.spec.source.repoURL }}\"\n    {{- else if .app.spec.sources }}\n      {{-
-        range .app.spec.sources }}\n        \"{{ .repoURL }}\"\n      {{- end }}\n    {{-
-        else }}\n      \"no repoURL\"\n    {{- end }}\n}\n{{range $index, $c := .app.status.conditions}}\n
-        \ ,\n  {\n    \"name\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\"\n
-        \ }\n{{end}}\n]\n"
-      potentialAction: "[{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Application\",\n
-        \ \"targets\":[{\n    \"os\":\"default\",\n    \"uri\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\"\n
-        \ }]\n},\n{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Repository\",\n  \"targets\":[{\n
-        \   \"os\":\"default\",\n    \"uri\": \n      {{- if .app.spec.source }}\n        \"{{
-        .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources }}\n        {{-
-        range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{- end }}\n
-        \     {{- else }}\n        \"no repoURL\"\n      {{- end }}\n  }]\n}]\n"
+      facts: |
+        [{
+          "name": "Health Status",
+          "value": "{{.app.status.health.status}}"
+        },
+        {
+          "name": "Repository",
+          "value": |
+            {{- if .app.spec.source }}
+              "{{ .app.spec.source.repoURL }}"
+            {{- else if .app.spec.sources }}
+              {{- range .app.spec.sources }}
+                "{{ .repoURL }}"
+              {{- end }}
+            {{- else }}
+              "no repoURL"
+            {{- end }}
+        }
+        {{range $index, $c := .app.status.conditions}}
+          ,
+          {
+            "name": "{{$c.type}}",
+            "value": "{{$c.message}}"
+          }
+        {{end}}
+        ]
+      potentialAction: |-
+        [{
+          "@type":"OpenUri",
+          "name":"Open Application",
+          "targets":[{
+            "os":"default",
+            "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+          }]
+        },
+        {
+          "@type":"OpenUri",
+          "name":"Open Repository",
+          "targets":[{
+            "os":"default",
+            "uri": |
+              {{- if .app.spec.source }}
+                "{{ .app.spec.source.repoURL }}"
+              {{- else if .app.spec.sources }}
+                {{- range .app.spec.sources }}
+                  "{{ .repoURL }}"
+                {{- end }}
+              {{- else }}
+                "no repoURL"
+              {{- end }}
+          }]
+        }]
       themeColor: '#FF0000'
       title: Application {{.app.metadata.name}} has degraded.
   template.app-sync-failed: |
@@ -94,35 +227,101 @@ data:
       {{if eq .serviceType "slack"}}:exclamation:{{end}}  The sync operation of application {{.app.metadata.name}} has failed at {{.app.status.operationState.finishedAt}} with the following error: {{.app.status.operationState.message}}
       Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
     slack:
-      attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-        \ \"color\": \"#E96D76\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
-        \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
-        \   \"title\": \"Repository\",\n    \"value\": \n      {{- if .app.spec.source
-        }}\n        \"{{ .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources
-        }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{-
-        end }}\n      {{- else }}\n        \"no repoURL\"\n      {{- end }}\n    \"short\":
-        true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  ,\n  {\n    \"title\":
-        \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n
-        \ {{end}}\n  ]\n}]\n"
+      attachments: |
+        [{
+          "title": "{{ .app.metadata.name}}",
+          "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+          "color": "#E96D76",
+          "fields": [
+          {
+            "title": "Sync Status",
+            "value": "{{.app.status.sync.status}}",
+            "short": true
+          },
+          {
+            "title": "Repository",
+            "value": |
+              {{- if .app.spec.source }}
+                "{{ .app.spec.source.repoURL }}"
+              {{- else if .app.spec.sources }}
+                {{- range .app.spec.sources }}
+                  "{{ .repoURL }}"
+                {{- end }}
+              {{- else }}
+                "no repoURL"
+              {{- end }}
+            "short": true
+          }
+          {{range $index, $c := .app.status.conditions}}
+          ,
+          {
+            "title": "{{$c.type}}",
+            "value": "{{$c.message}}",
+            "short": true
+          }
+          {{end}}
+          ]
+        }]
       deliveryPolicy: Post
       groupingKey: ""
       notifyBroadcast: false
     teams:
-      facts: "[{\n  \"name\": \"Sync Status\",\n  \"value\": \"{{.app.status.sync.status}}\"\n},\n{\n
-        \ \"name\": \"Failed at\",\n  \"value\": \"{{.app.status.operationState.finishedAt}}\"\n},\n{\n
-        \ \"name\": \"Repository\",\n  \"value\": \n    {{- if .app.spec.source }}\n      \"{{
-        .app.spec.source.repoURL }}\"\n    {{- else if .app.spec.sources }}\n      {{-
-        range .app.spec.sources }}\n        \"{{ .repoURL }}\"\n      {{- end }}\n    {{-
-        else }}\n      \"no repoURL\"\n    {{- end }}\n}\n{{range $index, $c := .app.status.conditions}}\n
-        \ ,\n  {\n    \"name\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\"\n
-        \ }\n{{end}}\n]\n"
-      potentialAction: "[{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Operation\",\n
-        \ \"targets\":[{\n    \"os\":\"default\",\n    \"uri\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true\"\n
-        \ }]\n},\n{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Repository\",\n  \"targets\":[{\n
-        \   \"os\":\"default\",\n    \"uri\": \n      {{- if .app.spec.source }}\n        \"{{
-        .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources }}\n        {{-
-        range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{- end }}\n
-        \     {{- else }}\n        \"no repoURL\"\n      {{- end }} \n  }]\n}]"
+      facts: |
+        [{
+          "name": "Sync Status",
+          "value": "{{.app.status.sync.status}}"
+        },
+        {
+          "name": "Failed at",
+          "value": "{{.app.status.operationState.finishedAt}}"
+        },
+        {
+          "name": "Repository",
+          "value": |
+            {{- if .app.spec.source }}
+              "{{ .app.spec.source.repoURL }}"
+            {{- else if .app.spec.sources }}
+              {{- range .app.spec.sources }}
+                "{{ .repoURL }}"
+              {{- end }}
+            {{- else }}
+              "no repoURL"
+            {{- end }}
+        }
+        {{range $index, $c := .app.status.conditions}}
+          ,
+          {
+            "name": "{{$c.type}}",
+            "value": "{{$c.message}}"
+          }
+        {{end}}
+        ]
+      potentialAction: |-
+        [{
+          "@type":"OpenUri",
+          "name":"Open Operation",
+          "targets":[{
+            "os":"default",
+            "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+          }]
+        },
+        {
+          "@type":"OpenUri",
+          "name":"Open Repository",
+          "targets":[{
+            "os":"default",
+            "uri": |
+              {{- if .app.spec.source }}
+                "{{ .app.spec.source.repoURL }}"
+              {{- else if .app.spec.sources }}
+                {{- range .app.spec.sources }}
+                  "{{ .repoURL }}"
+                {{- end }}
+              {{- else }}
+                "no repoURL"
+              {{- end }}
+          }]
+        }]
       themeColor: '#FF0000'
       title: Failed to sync application {{.app.metadata.name}}.
   template.app-sync-running: |
@@ -132,35 +331,101 @@ data:
       The sync operation of application {{.app.metadata.name}} has started at {{.app.status.operationState.startedAt}}.
       Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
     slack:
-      attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-        \ \"color\": \"#0DADEA\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
-        \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
-        \   \"title\": \"Repository\",\n    \"value\": \n      {{- if .app.spec.source
-        }}\n        \"{{ .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources
-        }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{-
-        end }}\n      {{- else }}\n        \"no repoURL\"\n      {{- end }}\n    \"short\":
-        true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  ,\n  {\n    \"title\":
-        \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n
-        \ {{end}}\n  ]\n}]\n"
+      attachments: |
+        [{
+          "title": "{{ .app.metadata.name}}",
+          "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+          "color": "#0DADEA",
+          "fields": [
+          {
+            "title": "Sync Status",
+            "value": "{{.app.status.sync.status}}",
+            "short": true
+          },
+          {
+            "title": "Repository",
+            "value": |
+              {{- if .app.spec.source }}
+                "{{ .app.spec.source.repoURL }}"
+              {{- else if .app.spec.sources }}
+                {{- range .app.spec.sources }}
+                  "{{ .repoURL }}"
+                {{- end }}
+              {{- else }}
+                "no repoURL"
+              {{- end }}
+            "short": true
+          }
+          {{range $index, $c := .app.status.conditions}}
+          ,
+          {
+            "title": "{{$c.type}}",
+            "value": "{{$c.message}}",
+            "short": true
+          }
+          {{end}}
+          ]
+        }]
       deliveryPolicy: Post
       groupingKey: ""
       notifyBroadcast: false
     teams:
-      facts: "[{\n  \"name\": \"Sync Status\",\n  \"value\": \"{{.app.status.sync.status}}\"\n},\n{\n
-        \ \"name\": \"Started at\",\n  \"value\": \"{{.app.status.operationState.startedAt}}\"\n},\n{\n
-        \ \"name\": \"Repository\",\n  \"value\": \n    {{- if .app.spec.source }}\n      \"{{
-        .app.spec.source.repoURL }}\"\n    {{- else if .app.spec.sources }}\n      {{-
-        range .app.spec.sources }}\n        \"{{ .repoURL }}\"\n      {{- end }}\n    {{-
-        else }}\n      \"no repoURL\"\n    {{- end }}\n}\n{{range $index, $c := .app.status.conditions}}\n
-        \ ,\n  {\n    \"name\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\"\n
-        \ }\n{{end}}\n]\n"
-      potentialAction: "[{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Operation\",\n
-        \ \"targets\":[{\n    \"os\":\"default\",\n    \"uri\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true\"\n
-        \ }]\n},\n{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Repository\",\n  \"targets\":[{\n
-        \   \"os\":\"default\",\n    \"uri\": \n      {{- if .app.spec.source }}\n        \"{{
-        .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources }}\n        {{-
-        range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{- end }}\n
-        \     {{- else }}\n        \"no repoURL\"\n      {{- end }} \n  }]\n}]"
+      facts: |
+        [{
+          "name": "Sync Status",
+          "value": "{{.app.status.sync.status}}"
+        },
+        {
+          "name": "Started at",
+          "value": "{{.app.status.operationState.startedAt}}"
+        },
+        {
+          "name": "Repository",
+          "value": |
+            {{- if .app.spec.source }}
+              "{{ .app.spec.source.repoURL }}"
+            {{- else if .app.spec.sources }}
+              {{- range .app.spec.sources }}
+                "{{ .repoURL }}"
+              {{- end }}
+            {{- else }}
+              "no repoURL"
+            {{- end }}
+        }
+        {{range $index, $c := .app.status.conditions}}
+          ,
+          {
+            "name": "{{$c.type}}",
+            "value": "{{$c.message}}"
+          }
+        {{end}}
+        ]
+      potentialAction: |-
+        [{
+          "@type":"OpenUri",
+          "name":"Open Operation",
+          "targets":[{
+            "os":"default",
+            "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+          }]
+        },
+        {
+          "@type":"OpenUri",
+          "name":"Open Repository",
+          "targets":[{
+            "os":"default",
+            "uri": |
+              {{- if .app.spec.source }}
+                "{{ .app.spec.source.repoURL }}"
+              {{- else if .app.spec.sources }}
+                {{- range .app.spec.sources }}
+                  "{{ .repoURL }}"
+                {{- end }}
+              {{- else }}
+                "no repoURL"
+              {{- end }}
+          }]
+        }]
       title: Start syncing application {{.app.metadata.name}}.
   template.app-sync-status-unknown: |
     email:
@@ -174,34 +439,97 @@ data:
       {{end}}
       {{end}}
     slack:
-      attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-        \ \"color\": \"#E96D76\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
-        \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
-        \   \"title\": \"Repository\",\n    \"value\": \n      {{- if .app.spec.source
-        }}\n        \"{{ .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources
-        }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{-
-        end }}\n      {{- else }}\n        \"no repoURL\"\n      {{- end }}\n    \"short\":
-        true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  ,\n  {\n    \"title\":
-        \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n
-        \ {{end}}\n  ]\n}]\n"
+      attachments: |
+        [{
+          "title": "{{ .app.metadata.name}}",
+          "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+          "color": "#E96D76",
+          "fields": [
+          {
+            "title": "Sync Status",
+            "value": "{{.app.status.sync.status}}",
+            "short": true
+          },
+          {
+            "title": "Repository",
+            "value": |
+              {{- if .app.spec.source }}
+                "{{ .app.spec.source.repoURL }}"
+              {{- else if .app.spec.sources }}
+                {{- range .app.spec.sources }}
+                  "{{ .repoURL }}"
+                {{- end }}
+              {{- else }}
+                "no repoURL"
+              {{- end }}
+            "short": true
+          }
+          {{range $index, $c := .app.status.conditions}}
+          ,
+          {
+            "title": "{{$c.type}}",
+            "value": "{{$c.message}}",
+            "short": true
+          }
+          {{end}}
+          ]
+        }]
       deliveryPolicy: Post
       groupingKey: ""
       notifyBroadcast: false
     teams:
-      facts: "[{\n  \"name\": \"Sync Status\",\n  \"value\": \"{{.app.status.sync.status}}\"\n},\n{\n
-        \ \"name\": \"Repository\",\n  \"value\": \n  {{- if .app.spec.source }}\n    \"{{
-        .app.spec.source.repoURL }}\"\n  {{- else if .app.spec.sources }}\n    {{- range
-        .app.spec.sources }}\n      \"{{ .repoURL }}\"\n    {{- end }}\n  {{- else }}\n
-        \   \"no repoURL\"\n  {{- end }}\n}\n{{range $index, $c := .app.status.conditions}}\n
-        \ ,\n  {\n    \"name\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\"\n
-        \ }\n{{end}}\n]\n"
-      potentialAction: "[{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Application\",\n
-        \ \"targets\":[{\n    \"os\":\"default\",\n    \"uri\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\"\n
-        \ }]\n},\n{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Repository\",\n  \"targets\":[{\n
-        \   \"os\":\"default\",\n    \"uri\": \n      {{- if .app.spec.source }}\n        \"{{
-        .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources }}\n        {{-
-        range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{- end }}\n
-        \     {{- else }}\n        \"no repoURL\"\n      {{- end }} \n  }]\n}]"
+      facts: |
+        [{
+          "name": "Sync Status",
+          "value": "{{.app.status.sync.status}}"
+        },
+        {
+          "name": "Repository",
+          "value": |
+          {{- if .app.spec.source }}
+            "{{ .app.spec.source.repoURL }}"
+          {{- else if .app.spec.sources }}
+            {{- range .app.spec.sources }}
+              "{{ .repoURL }}"
+            {{- end }}
+          {{- else }}
+            "no repoURL"
+          {{- end }}
+        }
+        {{range $index, $c := .app.status.conditions}}
+          ,
+          {
+            "name": "{{$c.type}}",
+            "value": "{{$c.message}}"
+          }
+        {{end}}
+        ]
+      potentialAction: |-
+        [{
+          "@type":"OpenUri",
+          "name":"Open Application",
+          "targets":[{
+            "os":"default",
+            "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+          }]
+        },
+        {
+          "@type":"OpenUri",
+          "name":"Open Repository",
+          "targets":[{
+            "os":"default",
+            "uri": |
+              {{- if .app.spec.source }}
+                "{{ .app.spec.source.repoURL }}"
+              {{- else if .app.spec.sources }}
+                {{- range .app.spec.sources }}
+                  "{{ .repoURL }}"
+                {{- end }}
+              {{- else }}
+                "no repoURL"
+              {{- end }}
+          }]
+        }]
       title: Application {{.app.metadata.name}} sync status is 'Unknown'
   template.app-sync-succeeded: |
     email:
@@ -210,36 +538,101 @@ data:
       {{if eq .serviceType "slack"}}:white_check_mark:{{end}} Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.
       Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
     slack:
-      attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-        \ \"color\": \"#18be52\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
-        \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
-        \   \"title\": \"Repository\",\n    \"value\": \n      {{- if .app.spec.source
-        }}\n        \"{{ .app.spec.source.repoURL }}\"\n      {{- else if .app.spec.sources
-        }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL }}\"\n        {{-
-        end }}\n      {{- else }}\n        \"no repoURL\"\n      {{- end }}\n    \"short\":
-        true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  ,\n  {\n    \"title\":
-        \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n
-        \ {{end}}\n  ]\n}]\n"
+      attachments: |
+        [{
+          "title": "{{ .app.metadata.name}}",
+          "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+          "color": "#18be52",
+          "fields": [
+          {
+            "title": "Sync Status",
+            "value": "{{.app.status.sync.status}}",
+            "short": true
+          },
+          {
+            "title": "Repository",
+            "value": |
+              {{- if .app.spec.source }}
+                "{{ .app.spec.source.repoURL }}"
+              {{- else if .app.spec.sources }}
+                {{- range .app.spec.sources }}
+                  "{{ .repoURL }}"
+                {{- end }}
+              {{- else }}
+                "no repoURL"
+              {{- end }}
+            "short": true
+          }
+          {{range $index, $c := .app.status.conditions}}
+          ,
+          {
+            "title": "{{$c.type}}",
+            "value": "{{$c.message}}",
+            "short": true
+          }
+          {{end}}
+          ]
+        }]
       deliveryPolicy: Post
       groupingKey: ""
       notifyBroadcast: false
     teams:
-      facts: "[{\n  \"name\": \"Sync Status\",\n  \"value\": \"{{.app.status.sync.status}}\"\n},\n{\n
-        \ \"name\": \"Synced at\",\n  \"value\": \"{{.app.status.operationState.finishedAt}}\"\n},\n{\n
-        \ \"name\": \"Repository\",\n  \"value\": \n    {{- if .app.spec.source }}\n      \"{{
-        .app.spec.source.repoURL }}\"\n    {{- else if .app.spec.sources }}\n      {{-
-        range .app.spec.sources }}\n        \"{{ .repoURL }}\"\n      {{- end }}\n    {{-
-        else }}\n      \"no repoURL\"\n    {{- end }}\n}\n{{range $index, $c := .app.status.conditions}}\n
-        \ ,\n  {\n    \"name\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\"\n
-        \ }\n{{end}}\n]\n"
-      potentialAction: "[{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Operation Details\",\n
-        \ \"targets\":[{\n    \"os\":\"default\",\n    \"uri\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true\"\n
-        \ }]\n},\n{\n  \"@type\":\"OpenUri\",\n  \"name\":\"Open Repository\",\n  \"targets\":[{\n
-        \   \"os\":\"default\",\n    \"uri\": \n      {{- if .app.spec.source }}\n        \"{{
-        .app.spec.source.repoURL | call .repo.RepoURLToHTTPS }}\"\n      {{- else if .app.spec.sources
-        }}\n        {{- range .app.spec.sources }}\n          \"{{ .repoURL | call .repo.RepoURLToHTTPS
-        }}\"\n        {{- end }}\n      {{- else }}\n        \"no repoURL\"\n      {{-
-        end }}\n  }]\n}]"
+      facts: |
+        [{
+          "name": "Sync Status",
+          "value": "{{.app.status.sync.status}}"
+        },
+        {
+          "name": "Synced at",
+          "value": "{{.app.status.operationState.finishedAt}}"
+        },
+        {
+          "name": "Repository",
+          "value": |
+            {{- if .app.spec.source }}
+              "{{ .app.spec.source.repoURL }}"
+            {{- else if .app.spec.sources }}
+              {{- range .app.spec.sources }}
+                "{{ .repoURL }}"
+              {{- end }}
+            {{- else }}
+              "no repoURL"
+            {{- end }}
+        }
+        {{range $index, $c := .app.status.conditions}}
+          ,
+          {
+            "name": "{{$c.type}}",
+            "value": "{{$c.message}}"
+          }
+        {{end}}
+        ]
+      potentialAction: |-
+        [{
+          "@type":"OpenUri",
+          "name":"Operation Details",
+          "targets":[{
+            "os":"default",
+            "uri":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+          }]
+        },
+        {
+          "@type":"OpenUri",
+          "name":"Open Repository",
+          "targets":[{
+            "os":"default",
+            "uri": |
+              {{- if .app.spec.source }}
+                "{{ .app.spec.source.repoURL | call .repo.RepoURLToHTTPS }}"
+              {{- else if .app.spec.sources }}
+                {{- range .app.spec.sources }}
+                  "{{ .repoURL | call .repo.RepoURLToHTTPS }}"
+                {{- end }}
+              {{- else }}
+                "no repoURL"
+              {{- end }}
+          }]
+        }]
       themeColor: '#000080'
       title: Application {{.app.metadata.name}} has been successfully synced
   trigger.on-created: |

--- a/notifications_catalog/templates/app-deployed.yaml
+++ b/notifications_catalog/templates/app-deployed.yaml
@@ -16,16 +16,7 @@ slack:
           },
           {
             "title": "Repository",
-            "value": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
             "short": true
           },
           {
@@ -53,16 +44,7 @@ teams:
         },
         {
           "name": "Repository",
-          "value": |
-            {{- if .app.spec.source }}
-              "{{ .app.spec.source.repoURL }}"
-            {{- else if .app.spec.sources }}
-              {{- range .app.spec.sources }}
-                "{{ .repoURL }}"
-              {{- end }}
-            {{- else }}
-              "no repoURL"
-            {{- end }}
+          "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         },
         {
           "name": "Revision",
@@ -90,15 +72,6 @@ teams:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
           }]
         }]

--- a/notifications_catalog/templates/app-deployed.yaml
+++ b/notifications_catalog/templates/app-deployed.yaml
@@ -16,7 +16,7 @@ slack:
           },
           {
             "title": "Repository",
-            "value": 
+            "value": |
               {{- if .app.spec.source }}
                 "{{ .app.spec.source.repoURL }}"
               {{- else if .app.spec.sources }}
@@ -53,7 +53,7 @@ teams:
         },
         {
           "name": "Repository",
-          "value": 
+          "value": |
             {{- if .app.spec.source }}
               "{{ .app.spec.source.repoURL }}"
             {{- else if .app.spec.sources }}
@@ -90,7 +90,7 @@ teams:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": 
+            "uri": |
               {{- if .app.spec.source }}
                 "{{ .app.spec.source.repoURL }}"
               {{- else if .app.spec.sources }}

--- a/notifications_catalog/templates/app-health-degraded.yaml
+++ b/notifications_catalog/templates/app-health-degraded.yaml
@@ -17,16 +17,7 @@ slack:
           },
           {
             "title": "Repository",
-            "value": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
             "short": true
           }
           {{range $index, $c := .app.status.conditions}}
@@ -49,16 +40,7 @@ teams:
         },
         {
           "name": "Repository",
-          "value": |
-            {{- if .app.spec.source }}
-              "{{ .app.spec.source.repoURL }}"
-            {{- else if .app.spec.sources }}
-              {{- range .app.spec.sources }}
-                "{{ .repoURL }}"
-              {{- end }}
-            {{- else }}
-              "no repoURL"
-            {{- end }}
+          "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         }
         {{range $index, $c := .app.status.conditions}}
           ,
@@ -82,15 +64,6 @@ teams:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
           }]
         }]

--- a/notifications_catalog/templates/app-health-degraded.yaml
+++ b/notifications_catalog/templates/app-health-degraded.yaml
@@ -17,7 +17,7 @@ slack:
           },
           {
             "title": "Repository",
-            "value": 
+            "value": |
               {{- if .app.spec.source }}
                 "{{ .app.spec.source.repoURL }}"
               {{- else if .app.spec.sources }}
@@ -49,7 +49,7 @@ teams:
         },
         {
           "name": "Repository",
-          "value": 
+          "value": |
             {{- if .app.spec.source }}
               "{{ .app.spec.source.repoURL }}"
             {{- else if .app.spec.sources }}
@@ -82,7 +82,7 @@ teams:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": 
+            "uri": |
               {{- if .app.spec.source }}
                 "{{ .app.spec.source.repoURL }}"
               {{- else if .app.spec.sources }}

--- a/notifications_catalog/templates/app-sync-failed.yaml
+++ b/notifications_catalog/templates/app-sync-failed.yaml
@@ -17,16 +17,7 @@ slack:
           },
           {
             "title": "Repository",
-            "value": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
             "short": true
           }
           {{range $index, $c := .app.status.conditions}}
@@ -53,16 +44,7 @@ teams:
         },
         {
           "name": "Repository",
-          "value": |
-            {{- if .app.spec.source }}
-              "{{ .app.spec.source.repoURL }}"
-            {{- else if .app.spec.sources }}
-              {{- range .app.spec.sources }}
-                "{{ .repoURL }}"
-              {{- end }}
-            {{- else }}
-              "no repoURL"
-            {{- end }}
+          "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         }
         {{range $index, $c := .app.status.conditions}}
           ,
@@ -86,15 +68,6 @@ teams:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
           }]
         }]

--- a/notifications_catalog/templates/app-sync-failed.yaml
+++ b/notifications_catalog/templates/app-sync-failed.yaml
@@ -17,7 +17,7 @@ slack:
           },
           {
             "title": "Repository",
-            "value": 
+            "value": |
               {{- if .app.spec.source }}
                 "{{ .app.spec.source.repoURL }}"
               {{- else if .app.spec.sources }}
@@ -53,7 +53,7 @@ teams:
         },
         {
           "name": "Repository",
-          "value": 
+          "value": |
             {{- if .app.spec.source }}
               "{{ .app.spec.source.repoURL }}"
             {{- else if .app.spec.sources }}
@@ -86,7 +86,7 @@ teams:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": 
+            "uri": |
               {{- if .app.spec.source }}
                 "{{ .app.spec.source.repoURL }}"
               {{- else if .app.spec.sources }}
@@ -95,6 +95,6 @@ teams:
                 {{- end }}
               {{- else }}
                 "no repoURL"
-              {{- end }} 
+              {{- end }}
           }]
         }]

--- a/notifications_catalog/templates/app-sync-running.yaml
+++ b/notifications_catalog/templates/app-sync-running.yaml
@@ -17,16 +17,7 @@ slack:
           },
           {
             "title": "Repository",
-            "value": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
             "short": true
           }
           {{range $index, $c := .app.status.conditions}}
@@ -52,16 +43,7 @@ teams:
         },
         {
           "name": "Repository",
-          "value": |
-            {{- if .app.spec.source }}
-              "{{ .app.spec.source.repoURL }}"
-            {{- else if .app.spec.sources }}
-              {{- range .app.spec.sources }}
-                "{{ .repoURL }}"
-              {{- end }}
-            {{- else }}
-              "no repoURL"
-            {{- end }}
+          "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         }
         {{range $index, $c := .app.status.conditions}}
           ,
@@ -85,15 +67,6 @@ teams:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
           }]
         }]

--- a/notifications_catalog/templates/app-sync-running.yaml
+++ b/notifications_catalog/templates/app-sync-running.yaml
@@ -17,7 +17,7 @@ slack:
           },
           {
             "title": "Repository",
-            "value": 
+            "value": |
               {{- if .app.spec.source }}
                 "{{ .app.spec.source.repoURL }}"
               {{- else if .app.spec.sources }}
@@ -52,7 +52,7 @@ teams:
         },
         {
           "name": "Repository",
-          "value": 
+          "value": |
             {{- if .app.spec.source }}
               "{{ .app.spec.source.repoURL }}"
             {{- else if .app.spec.sources }}
@@ -85,7 +85,7 @@ teams:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": 
+            "uri": |
               {{- if .app.spec.source }}
                 "{{ .app.spec.source.repoURL }}"
               {{- else if .app.spec.sources }}
@@ -94,6 +94,6 @@ teams:
                 {{- end }}
               {{- else }}
                 "no repoURL"
-              {{- end }} 
+              {{- end }}
           }]
         }]

--- a/notifications_catalog/templates/app-sync-status-unknown.yaml
+++ b/notifications_catalog/templates/app-sync-status-unknown.yaml
@@ -22,16 +22,7 @@ slack:
           },
           {
             "title": "Repository",
-            "value": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
             "short": true
           }
           {{range $index, $c := .app.status.conditions}}
@@ -53,16 +44,7 @@ teams:
         },
         {
           "name": "Repository",
-          "value": |
-          {{- if .app.spec.source }}
-            "{{ .app.spec.source.repoURL }}"
-          {{- else if .app.spec.sources }}
-            {{- range .app.spec.sources }}
-              "{{ .repoURL }}"
-            {{- end }}
-          {{- else }}
-            "no repoURL"
-          {{- end }}
+          "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         }
         {{range $index, $c := .app.status.conditions}}
           ,
@@ -86,15 +68,6 @@ teams:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
           }]
         }]

--- a/notifications_catalog/templates/app-sync-status-unknown.yaml
+++ b/notifications_catalog/templates/app-sync-status-unknown.yaml
@@ -22,7 +22,7 @@ slack:
           },
           {
             "title": "Repository",
-            "value": 
+            "value": |
               {{- if .app.spec.source }}
                 "{{ .app.spec.source.repoURL }}"
               {{- else if .app.spec.sources }}
@@ -53,7 +53,7 @@ teams:
         },
         {
           "name": "Repository",
-          "value": 
+          "value": |
           {{- if .app.spec.source }}
             "{{ .app.spec.source.repoURL }}"
           {{- else if .app.spec.sources }}
@@ -86,7 +86,7 @@ teams:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": 
+            "uri": |
               {{- if .app.spec.source }}
                 "{{ .app.spec.source.repoURL }}"
               {{- else if .app.spec.sources }}
@@ -95,6 +95,6 @@ teams:
                 {{- end }}
               {{- else }}
                 "no repoURL"
-              {{- end }} 
+              {{- end }}
           }]
         }]

--- a/notifications_catalog/templates/app-sync-succeeded.yaml
+++ b/notifications_catalog/templates/app-sync-succeeded.yaml
@@ -17,16 +17,7 @@ slack:
           },
           {
             "title": "Repository",
-            "value": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
             "short": true
           }
           {{range $index, $c := .app.status.conditions}}
@@ -53,16 +44,7 @@ teams:
         },
         {
           "name": "Repository",
-          "value": |
-            {{- if .app.spec.source }}
-              "{{ .app.spec.source.repoURL }}"
-            {{- else if .app.spec.sources }}
-              {{- range .app.spec.sources }}
-                "{{ .repoURL }}"
-              {{- end }}
-            {{- else }}
-              "no repoURL"
-            {{- end }}
+          "value": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
         }
         {{range $index, $c := .app.status.conditions}}
           ,
@@ -86,15 +68,6 @@ teams:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": |
-              {{- if .app.spec.source }}
-                "{{ .app.spec.source.repoURL | call .repo.RepoURLToHTTPS }}"
-              {{- else if .app.spec.sources }}
-                {{- range .app.spec.sources }}
-                  "{{ .repoURL | call .repo.RepoURLToHTTPS }}"
-                {{- end }}
-              {{- else }}
-                "no repoURL"
-              {{- end }}
+            "uri": {{- if .app.spec.source }}"{{ .app.spec.source.repoURL }}"{{- else if .app.spec.sources }}"{{- range .app.spec.sources }}{{ .repoURL }}\n{{- end }}"{{- else }}"no repoURL"{{- end }}
           }]
         }]

--- a/notifications_catalog/templates/app-sync-succeeded.yaml
+++ b/notifications_catalog/templates/app-sync-succeeded.yaml
@@ -17,7 +17,7 @@ slack:
           },
           {
             "title": "Repository",
-            "value": 
+            "value": |
               {{- if .app.spec.source }}
                 "{{ .app.spec.source.repoURL }}"
               {{- else if .app.spec.sources }}
@@ -53,7 +53,7 @@ teams:
         },
         {
           "name": "Repository",
-          "value": 
+          "value": |
             {{- if .app.spec.source }}
               "{{ .app.spec.source.repoURL }}"
             {{- else if .app.spec.sources }}
@@ -86,7 +86,7 @@ teams:
           "name":"Open Repository",
           "targets":[{
             "os":"default",
-            "uri": 
+            "uri": |
               {{- if .app.spec.source }}
                 "{{ .app.spec.source.repoURL | call .repo.RepoURLToHTTPS }}"
               {{- else if .app.spec.sources }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

TO-BE: catalog.md와 install.yaml에 대한 들여쓰기 에러를 해결하였습니다.

Changes: 각 파일에 `|` 를 넣어 yaml의 텍스트 블록 정의 문법을 사용하였습니다 
