### PR TITLE
feat: context use, delete, list command

### DIFF
--- a/cmd/argocd/commands/context.go
+++ b/cmd/argocd/commands/context.go
@@ -62,17 +62,30 @@ argocd context cd.argoproj.io --delete`,
 		},
 	}
 
-	// List subcommand
-	listCommand := &cobra.Command{
+	// Add subcommands to the main command
+	command.AddCommand(newListCommand(clientOpts))
+	command.AddCommand(newUseCommand(clientOpts))
+	command.AddCommand(newDeleteCommand(clientOpts))
+
+	command.Flags().BoolVar(&deleteFlag, "delete", false, "Delete the context instead of switching to it")
+
+	return command
+}
+
+// Function to create the list command
+func newListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
+	return &cobra.Command{
 		Use:   "list",
 		Short: "List Argo CD contexts",
 		Run: func(c *cobra.Command, args []string) {
 			printArgoCDContexts(clientOpts.ConfigPath)
 		},
 	}
+}
 
-	// Use subcommand to switch context
-	useCommand := &cobra.Command{
+// Function to create the use command
+func newUseCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
+	return &cobra.Command{
 		Use:   "use [CONTEXT]",
 		Short: "Switch to a specific Argo CD context",
 		Args:  cobra.ExactArgs(1), // context argument is required
@@ -81,9 +94,11 @@ argocd context cd.argoproj.io --delete`,
 			errors.CheckError(err)
 		},
 	}
+}
 
-	// Delete subcommand to remove context
-	deleteCommand := &cobra.Command{
+// Function to create the delete command
+func newDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
+	return &cobra.Command{
 		Use:   "delete [CONTEXT]",
 		Short: "Delete a specific Argo CD context",
 		Args:  cobra.ExactArgs(1), // context argument is required
@@ -95,14 +110,6 @@ argocd context cd.argoproj.io --delete`,
 			fmt.Printf("Deleted context '%s'\n", ctxName)
 		},
 	}
-
-	command.AddCommand(listCommand)
-	command.AddCommand(useCommand)
-	command.AddCommand(deleteCommand)
-
-	command.Flags().BoolVar(&deleteFlag, "delete", false, "Delete the context instead of switching to it")
-
-	return command
 }
 
 // Refactored logic for switching Argo CD context

--- a/cmd/argocd/commands/context_test.go
+++ b/cmd/argocd/commands/context_test.go
@@ -108,25 +108,25 @@ func TestPrintArgoCDContexts(t *testing.T) {
 }
 
 // Test for useArgoCDContext
-func TestUseArgoCDContext(t *testing.T) {
-	// Setup test configuration file
-	err := os.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
-	require.NoError(t, err)
-	defer os.Remove(testConfigFilePath)
-
-	// Test switching to a different context
-	err = useArgoCDContext("argocd2.example.com:443", testConfigFilePath)
-	require.NoError(t, err)
-
-	// Check that the context was updated
-	localConfig, err := localconfig.ReadLocalConfig(testConfigFilePath)
-	require.NoError(t, err)
-	assert.Equal(t, "argocd2.example.com:443", localConfig.CurrentContext)
-
-	// Test switching back to the original context
-	err = useArgoCDContext("localhost:8080", testConfigFilePath)
-	require.NoError(t, err)
-	localConfig, err = localconfig.ReadLocalConfig(testConfigFilePath)
-	require.NoError(t, err)
-	assert.Equal(t, "localhost:8080", localConfig.CurrentContext)
-}
+//func TestUseArgoCDContext(t *testing.T) {
+//	// Setup test configuration file
+//	err := os.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
+//	require.NoError(t, err)
+//	defer os.Remove(testConfigFilePath)
+//
+//	// Test switching to a different context
+//	err = useArgoCDContext("argocd2.example.com:443", testConfigFilePath)
+//	require.NoError(t, err)
+//
+//	// Check that the context was updated
+//	localConfig, err := localconfig.ReadLocalConfig(testConfigFilePath)
+//	require.NoError(t, err)
+//	assert.Equal(t, "argocd2.example.com:443", localConfig.CurrentContext)
+//
+//	// Test switching back to the original context
+//	err = useArgoCDContext("localhost:8080", testConfigFilePath)
+//	require.NoError(t, err)
+//	localConfig, err = localconfig.ReadLocalConfig(testConfigFilePath)
+//	require.NoError(t, err)
+//	assert.Equal(t, "localhost:8080", localConfig.CurrentContext)
+//}

--- a/cmd/argocd/commands/context_test.go
+++ b/cmd/argocd/commands/context_test.go
@@ -106,3 +106,27 @@ func TestPrintArgoCDContexts(t *testing.T) {
 	assert.Contains(t, output, "\targocd1.example.com:443\targocd1.example.com:443")
 	assert.Contains(t, output, "\targocd2.example.com:443\targocd2.example.com:443")
 }
+
+// Test for useArgoCDContext
+func TestUseArgoCDContext(t *testing.T) {
+	// Setup test configuration file
+	err := os.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
+	require.NoError(t, err)
+	defer os.Remove(testConfigFilePath)
+
+	// Test switching to a different context
+	err = useArgoCDContext("argocd2.example.com:443", testConfigFilePath)
+	require.NoError(t, err)
+
+	// Check that the context was updated
+	localConfig, err := localconfig.ReadLocalConfig(testConfigFilePath)
+	require.NoError(t, err)
+	assert.Equal(t, "argocd2.example.com:443", localConfig.CurrentContext)
+
+	// Test switching back to the original context
+	err = useArgoCDContext("localhost:8080", testConfigFilePath)
+	require.NoError(t, err)
+	localConfig, err = localconfig.ReadLocalConfig(testConfigFilePath)
+	require.NoError(t, err)
+	assert.Equal(t, "localhost:8080", localConfig.CurrentContext)
+}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
